### PR TITLE
Add rebellion and other missing editions

### DIFF
--- a/external-bridge.js
+++ b/external-bridge.js
@@ -173,7 +173,7 @@ async function logGameTransaction(tx, ext_chain) {
 	}
 
 	if(!data.token && data.edition != undefined) {
-		data.token = ['ALPHA', 'BETA', 'ORB', null, 'UNTAMED', 'DICE', 'GLADIUS', 'CHAOS', 'RIFT'][data.edition];
+		data.token = ['ALPHA', 'BETA', 'ORB', null, 'UNTAMED', 'DICE', 'GLADIUS', 'CHAOS', 'RIFT', 'NIGHTMARE', null, null, 'REBELLION'][data.edition];
 	} else if (data.cards) {
 		data.token = 'CARD';
 		data.qty = data.cards.length;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splinterlands/external-bridge",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Library to bridge transactions from an external blockchain to Splinterlands",
   "main": "external-bridge.js",
   "scripts": {


### PR DESCRIPTION
TODO on release:

- [ ] Publish new 1.4.3 version somehow? (not sure if this package actually gets published or if other repos just pull this repo directly)

This package seems to be used in a few places but not by version number, we need to somehow update these?
The following seem to be using logGameTransaction which will be require this update

- https://github.com/steem-monsters/hive-engine/blob/master/package.json
- https://github.com/steem-monsters/wax-splinterlands-broadcaster/blob/master/package.json